### PR TITLE
Fixed wrong variable name and added test cases to cover the bug.

### DIFF
--- a/Process/Coordinator/Coordinator.php
+++ b/Process/Coordinator/Coordinator.php
@@ -139,7 +139,7 @@ class Coordinator implements CoordinatorInterface
         if ($result instanceof ActionResult) {
             // Handle explicit jump to step.
             if ($result->getNextStepName()) {
-                $this->context->setNextStepByName($response->getNextStepName());
+                $this->context->setNextStepByName($result->getNextStepName());
 
                 return $this->redirectToStepDisplayAction($process, $this->context->getNextStep());
             }


### PR DESCRIPTION
Jumping to an other step is currently broken because of a wrong variable name.

Unfortunately this was not covered by the unit test.

I fixed the code and added some more tests.
