### PR TITLE
Made Coordinator::buildProcess protected

### DIFF
--- a/Process/Coordinator/Coordinator.php
+++ b/Process/Coordinator/Coordinator.php
@@ -242,7 +242,7 @@ class Coordinator implements CoordinatorInterface
      *
      * @return ProcessInterface
      */
-    private function buildProcess($scenarioAlias)
+    protected function buildProcess($scenarioAlias)
     {
         $processScenario = $this->loadScenario($scenarioAlias);
 


### PR DESCRIPTION
I extended it, and was unable to call `buildProcess` from parent class.
