### PR TITLE
Making sure the correct exception is thrown

### DIFF
--- a/Process/Process.php
+++ b/Process/Process.php
@@ -13,6 +13,7 @@ namespace Sylius\Bundle\FlowBundle\Process;
 
 use Sylius\Bundle\FlowBundle\Process\Step\StepInterface;
 use Sylius\Bundle\FlowBundle\Validator\ProcessValidatorInterface;
+use Sylius\Bundle\FlowBundle\Process\Coordinator\InvalidArgumentException;
 
 /**
  * Base class for process.
@@ -137,7 +138,7 @@ class Process implements ProcessInterface
     public function getStepByIndex($index)
     {
         if (!isset($this->orderedSteps[$index])) {
-            throw new \InvalidArgumentException(sprintf('Step with index %d. does not exist', $index));
+            throw new InvalidArgumentException(sprintf('Step with index %d. does not exist', $index));
         }
 
         return $this->orderedSteps[$index];
@@ -149,7 +150,7 @@ class Process implements ProcessInterface
     public function getStepByName($name)
     {
         if (!$this->hasStep($name)) {
-            throw new \InvalidArgumentException(sprintf('Step with name "%s" does not exist', $name));
+            throw new InvalidArgumentException(sprintf('Step with name "%s" does not exist', $name));
         }
 
         return $this->steps[$name];
@@ -185,7 +186,7 @@ class Process implements ProcessInterface
     public function addStep($name, StepInterface $step)
     {
         if ($this->hasStep($name)) {
-            throw new \InvalidArgumentException(sprintf('Step with name "%s" already exists', $name));
+            throw new InvalidArgumentException(sprintf('Step with name "%s" already exists', $name));
         }
 
         if (null === $step->getName()) {
@@ -201,7 +202,7 @@ class Process implements ProcessInterface
     public function removeStep($name)
     {
         if (!$this->hasStep($name)) {
-            throw new \InvalidArgumentException(sprintf('Step with name "%s" does not exist', $name));
+            throw new InvalidArgumentException(sprintf('Step with name "%s" does not exist', $name));
         }
 
         $index = array_search($this->steps[$name], $this->orderedSteps);


### PR DESCRIPTION
At the moment Process.php throws ```\InvalidArgumentException``` however the code which uses this class (```Sylius\Bundle\FlowBundle\Controller\ProcessController```) catches ```Sylius\Bundle\FlowBundle\Process\Coordinator\InvalidArgumentException``` instead resulting in 5xx error where 404 is expected