### PR TITLE
use ContainerAwareTrait instead of extending ContainerAware

### DIFF
--- a/Process/Step/AbstractContainerAwareStep.php
+++ b/Process/Step/AbstractContainerAwareStep.php
@@ -12,7 +12,7 @@
 namespace Sylius\Bundle\FlowBundle\Process\Step;
 
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 
 /**
  * Container aware step.
@@ -22,18 +22,5 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 abstract class AbstractContainerAwareStep extends AbstractStep implements ContainerAwareInterface
 {
-    /**
-     * Container.
-     *
-     * @var ContainerInterface
-     */
-    protected $container;
-
-    /**
-     * {@inheritdoc}
-     */
-    public function setContainer(ContainerInterface $container = null)
-    {
-        $this->container = $container;
-    }
+    use ContainerAwareTrait;
 }


### PR DESCRIPTION
Based on this https://github.com/Sylius/Sylius/issues/3698 issue, I tried a small pull-request.

I ran bin/phpspec and I got this results, so everything seems fine:

```
bin/phpspec run
                                      100%                                       56
13 specs
56 examples (56 passed)
160ms
```

What bothers me that even if I remove "implements ContainerAwareInterface" from Sylius\Bundle\FlowBundle\Process\Step\AbstractContainerAwareStep phpspec still tells me everything is fine.